### PR TITLE
support queryOne/returnFirst for array return types

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ var Product = resourceClient({
 - **options** - default request options for this action. Overrides defaults set for the resource. You can use any option from the [request](https://github.com/request/request) module. There are a couple extra options available:
   - **url** - same as request url but can contain variables prefixed with a colon such as `products/:name`
   - **isArray** - resource is an array. It will not populate variables in the url.
+  - **returnFirst** - resource is an array. It will return the first result from the array
 
 ```javascript
 var resourceClient = require('resource-client');
@@ -71,6 +72,12 @@ var Product = resourceClient({
 Product.action('query', {
   method: 'GET'
   isArray: true
+});
+
+Product.action('queryOne', {
+  method: 'GET'
+  isArray: true
+  returnFirst: true
 });
 ```
 
@@ -101,6 +108,7 @@ Every new resource will come with these methods by default
 
 - **get** - {method: 'GET'}
 - **query** - {method: 'GET', isArray: true}
+- **queryOne** - {method: 'GET', isArray: true, returnFirst: true}
 - **update** - {method: 'PUT'}
 - **save** - {method: 'POST'}
 - **remove** - {method: 'DELETE'}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "request": "^2.51.0",
     "lodash": "^3.0.0",
-    "url-assembler": "0.0.3"
+    "url-assembler": "0.0.3",
+    "chai": "^2.1.0"
   },
   "devDependencies": {
     "coffee-script": ">=1.7.x",

--- a/src/default_actions.coffee
+++ b/src/default_actions.coffee
@@ -4,6 +4,10 @@ module.exports =
   'query':
     method: 'GET'
     isArray: true
+  'queryOne':
+    method: 'GET'
+    isArray: true
+    returnFirst: true
   'save':
     method: 'POST'
   'update':

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -37,7 +37,7 @@ module.exports = resourceClient = (options) ->
           .query(queryParams)
           .toString()
         actionRequest {url: requestUrl}, (err, response) ->
-          handleResponse(err, response, null, done)
+          handleResponse(err, response, null, done, options)
 
     else if options.method in ['PUT', 'POST', 'DELETE']
       actionUrl = if options.method is 'POST' then baseUrl else url
@@ -61,12 +61,13 @@ module.exports = resourceClient = (options) ->
         actionRequest {url: requestUrl, body: @}, (err, response) ->
           handleResponse(err, response, @, done)
 
-  handleResponse = (err, response, originalObject, done) ->
+  handleResponse = (err, response, originalObject, done, options = {}) ->
     if err
       return done(err)
     else if 200 <= response.statusCode < 300
       if Array.isArray(response.body)
         resources = response.body.map (resource) -> new Resource(resource)
+        resources = resources[0] if options.returnFirst
         return done null, resources
       else
         resource =

--- a/test/resource_client.test.coffee
+++ b/test/resource_client.test.coffee
@@ -17,6 +17,10 @@ describe 'resource-client', ->
         products = @Product.sync.query()
         expect(products).to.have.length 3
 
+      it 'can return first product', fibrous ->
+        product = @Product.sync.queryOne()
+        expect(product).not.to.be.an.instanceof(Array)
+
       it 'applies query parameters', fibrous ->
         products = @Product.sync.query({name: ['apple', 'banana']})
         expect(products).to.have.length 2


### PR DESCRIPTION
I see on the code in some places Model.sync.query(...)?[0], using queryOne would eliminate the need to use ?[0] to guard for null and request first.
