### PR TITLE
JSON Schema Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Resource Client
 
-Easily create node API clients for your APIs. Inspired by [Angular Resource](https://docs.angularjs.org/api/ngResource/service/$resource).
+Easily create node API clients for your APIs. Inspired by [Angular Resource](https://docs.angularjs.org/api/ngResource/service/$resource) and [Angular Validated Resource](https://github.com/goodeggs/angular-validated-resource).
 
 [![NPM version](http://img.shields.io/npm/v/resource-client.svg?style=flat-square)](https://www.npmjs.org/package/resource-client)
 [![Build Status](http://img.shields.io/travis/goodeggs/resource-client.svg?style=flat-square)](https://travis-ci.org/goodeggs/resource-client)
@@ -36,6 +36,30 @@ Product.query({isActive: true}).then(function (products) {
 }).catch(function (err) {
   if (err) console.log err;
 });
+```
+
+You can also configure the resource to use JSON schema validation for every request:
+
+```javascript
+var resourceClient = require('resource-client');
+
+var Product = resourceClient({
+  url: 'http://www.mysite.com/api/products/:_id',
+  headers: {
+    'X-Secret-Token': 'ABCD1234'
+  }
+  // recommended that you do not allow unkown properties when testing.
+  banUnknownProperties: true
+});
+
+Product.action('update', {
+  method: 'PUT'
+  // will reject or pass error to callback if validation fails for any of the below
+  urlParamsSchema: require('./product_schemas/update/url_params.json')
+  queryParamsSchema: require('./product_schemas/update/query_params.json')
+  requestBodySchema: require('./product_schemas/update/request_body.json')
+  responseBodySchema: require('./product_schemas/update/response_body.json')
+})
 ```
 
 ## Creating a Resource

--- a/package.json
+++ b/package.json
@@ -23,15 +23,17 @@
   "bugs": "https://github.com/goodeggs/resource-client/issues",
   "dependencies": {
     "bluebird": "^2.9.30",
+    "goodeggs-json-schema-validator": "^2.0.2",
     "lodash": "^3.0.0",
     "request": "2.54.0",
     "url-assembler": "0.0.3"
   },
   "devDependencies": {
-    "coffee-script": ">=1.7.x",
-    "mocha": "~1.x.x",
     "chai": "^2.1.0",
+    "chai-as-promised": "^5.1.0",
+    "coffee-script": ">=1.7.x",
     "fibrous": "^0.3.3",
+    "mocha": "~1.x.x",
     "nock": "^1.6.1"
   },
   "publishConfig": {

--- a/src/request_validator.coffee
+++ b/src/request_validator.coffee
@@ -1,0 +1,162 @@
+_ = require 'lodash'
+Promise = require 'bluebird'
+validator = require 'goodeggs-json-schema-validator'
+
+
+module.exports =
+
+  ###
+  Throws if url params invalid
+  @param {Object} requestParams
+  @param {Object} actionConfig
+  @param {Object} resourceConfig
+  @param {String} actionName
+  @param {Object} [requestBody] - if the request has a body, use for populating '@' url params
+  ###
+  validateUrlParams: ({requestParams, actionConfig, resourceConfig, actionName, requestBody}) ->
+    throw new TypeError 'requestParams must be an object' unless typeof requestParams is 'object'
+    throw new TypeError 'actionConfig must be an object' unless typeof actionConfig is 'object'
+    throw new TypeError 'resourceConfig must be an object' unless typeof resourceConfig is 'object'
+    throw new TypeError 'actionName must be a string' unless typeof actionName is 'string'
+    throw new TypeError 'requestBody must be a string' if requestBody? and typeof requestBody isnt 'object'
+
+    return unless actionConfig.urlParamsSchema?
+    urlParams = getUrlParamValues({requestParams, actionConfig, resourceConfig, requestBody})
+
+    validate clean(urlParams), actionConfig.urlParamsSchema,
+      errorPrefix: "Url params validation failed for action '#{actionName}'"
+      banUnknownProperties: getBanUnkownProperties({actionConfig, resourceConfig})
+
+
+  ###
+  Throws if query params invalid
+  @param {Object} requestParams
+  @param {Object} actionConfig
+  @param {Object} resourceConfig
+  @param {String} actionName
+  @param {Object} [requestBody] - if the request has a body, use for populating '@' query params
+  ###
+  validateQueryParams: ({requestParams, actionConfig, resourceConfig, actionName, requestBody}) ->
+    throw new TypeError 'requestParams must be an object' unless typeof requestParams is 'object'
+    throw new TypeError 'actionConfig must be an object' unless typeof actionConfig is 'object'
+    throw new TypeError 'resourceConfig must be an object' unless typeof resourceConfig is 'object'
+    throw new TypeError 'actionName must be a string' unless typeof actionName is 'string'
+    throw new TypeError 'requestBody must be a string' if requestBody? and typeof requestBody isnt 'object'
+
+    return unless actionConfig.queryParamsSchema?
+    queryParams = getQueryParamValues({requestParams, actionConfig, resourceConfig, requestBody})
+
+    validate clean(queryParams), actionConfig.queryParamsSchema,
+      errorPrefix: "Query validation failed for action '#{actionName}'"
+      banUnknownProperties: getBanUnkownProperties({actionConfig, resourceConfig})
+
+
+  ###
+  Throws if request body invalid
+  @param {Object} actionConfig
+  @param {Object} resourceConfig
+  @param {Object} actionName
+  @param {Object} requestBody
+  ###
+  validateRequestBody: ({actionConfig, resourceConfig, actionName, requestBody}) ->
+    throw new TypeError 'actionConfig must be an object' unless typeof actionConfig is 'object'
+    throw new TypeError 'resourceConfig must be an object' unless typeof resourceConfig is 'object'
+    throw new TypeError 'actionName must be a string' unless typeof actionName is 'string'
+    throw new TypeError 'requestBody must be an object' unless typeof requestBody is 'object'
+
+    validate clean(requestBody), actionConfig.requestBodySchema,
+      errorPrefix: "Request body validation failed for action '#{actionName}'"
+      banUnknownProperties: getBanUnkownProperties({actionConfig, resourceConfig})
+
+
+  ###
+  Throws if response body invalid
+  @param {Object} actionConfig
+  @param {Object} resourceConfig
+  @param {Object} actionName
+  @param {Object} responseBody
+  ###
+  validateResponseBody: ({actionConfig, resourceConfig, actionName, responseBody}) ->
+    throw new TypeError 'actionConfig must be an object' unless typeof actionConfig is 'object'
+    throw new TypeError 'resourceConfig must be an object' unless typeof resourceConfig is 'object'
+    throw new TypeError 'actionName must be a string' unless typeof actionName is 'string'
+    throw new TypeError 'responseBody must be an object' unless typeof responseBody is 'object'
+
+    validate clean(responseBody), actionConfig.responseBodySchema,
+      errorPrefix: "Response body validation failed for action '#{actionName}'"
+      banUnknownProperties: getBanUnkownProperties({actionConfig, resourceConfig})
+
+
+# remove all prototype properties, and undefined fields
+clean = (resource) ->
+  JSON.parse JSON.stringify resource
+
+
+getUrlParams = (url) ->
+  regex = /\/:(\w*)/g
+  matches = []
+  match = regex.exec(url)
+  while match?
+    matches.push(match[1])
+    match = regex.exec(url)
+  matches
+
+
+getUrlParamValues = ({requestParams, actionConfig, resourceConfig, requestBody}) ->
+  allParams = _.assign({}, resourceConfig.params, actionConfig.params, requestParams)
+  url = if actionConfig.url? then actionConfig.url else resourceConfig.url
+  urlParams = getUrlParams(url)
+  paramsToOmit = []
+
+  # handle params with @ in value (e.g. {id: '@_id'})
+  for param, value of allParams
+    if param not in urlParams
+      paramsToOmit.push(param)
+    else if typeof value is 'string' and value.indexOf('@') is 0
+      # if @ value not in requestBody, remove from url params
+      if not requestBody?[value.slice(1)]?
+        paramsToOmit.push(param)
+      # if @ value in requestBody, reassign in url params with actual value
+      else
+        allParams[param] = requestBody?[value.slice(1)]
+  _.omit(allParams, paramsToOmit)
+
+
+getBanUnkownProperties = ({actionConfig, resourceConfig}) ->
+  if actionConfig.banUnknownProperties?
+    actionConfig.banUnknownProperties
+  else if resourceConfig.banUnknownProperties?
+    resourceConfig.banUnknownProperties
+  else
+    false
+
+
+getQueryParamValues = ({requestParams, actionConfig, resourceConfig, requestBody}) ->
+  url = if actionConfig.url? then actionConfig.url else resourceConfig.url
+  allParams = _.assign({}, resourceConfig.params, actionConfig.params, requestParams)
+  paramsToOmit = []
+
+  # handle params with @ in value (e.g. {id: '@_id'})
+  for param, value of allParams
+    if typeof value is 'string' and value.indexOf('@') is 0
+      # if @ value not in requestBody, remove from query params
+      if not requestBody?[value.slice(1)]?
+        paramsToOmit.push(param)
+      # if @ value in requestBody, reassign in query params with actual value
+      else
+        allParams[param] = requestBody?[value.slice(1)]
+
+  paramsToOmit = paramsToOmit.concat(getUrlParams(url))
+  _.omit(allParams, paramsToOmit)
+
+
+###
+Throws if validation fails
+###
+validate = (obj, schema, {errorPrefix, banUnknownProperties}) ->
+  banUnknownProperties ?= false
+  if schema? and not validator.validate(obj, schema, null, banUnknownProperties)
+    message = "#{errorPrefix}: #{validator.error.message}"
+    message += " at #{validator.error.dataPath}" if validator.error.dataPath?.length
+    throw new Error message
+

--- a/src/url_builder.coffee
+++ b/src/url_builder.coffee
@@ -2,10 +2,9 @@ UrlAssembler = require 'url-assembler'
 
 ###
 Build url from url template
-
 @param urlTemplate - url that can contain variables such as /products/:_id
-@param params - params to populate the url. Will fill url params first, and then
-all remaining params will become query params
+@param params - params to populate the url.
+  - Will fill url params first, and then all remaining params will become query params
 @param [body] - body object to use for populating params (when params are defined using @, eg. {_id: '@_id'})
 ###
 module.exports.build = (urlTemplate, params, body={}) ->

--- a/test/validation.test.coffee
+++ b/test/validation.test.coffee
@@ -1,0 +1,244 @@
+chai = require 'chai'
+chai.use require 'chai-as-promised'
+expect = chai.expect
+nock = require 'nock'
+request = require 'request'
+resourceClient = require '..'
+Promise = require 'bluebird'
+serverUrl = 'http://resource-client.com'
+
+describe 'resource-client validation', ->
+  describe 'validating urlParamsSchema', ->
+    it 'validates for GET', ->
+      @Product = resourceClient url: "#{serverUrl}/api/products/:_id"
+      @Product.action 'get',
+        method: 'GET'
+        params:
+          _id: '@_id'
+        urlParamsSchema:
+          type: 'object'
+          required: ['_id']
+          properties:
+            _id:
+              type: 'string'
+              format: 'objectid'
+
+      expect(@Product.get({_id: '123abc'})).to.be.rejectedWith 'Url params validation failed for action \'get\': Format validation failed (objectid expected) at /_id'
+
+    it 'validates for POST/PUT/DELETE class method', ->
+      @Product = resourceClient url: "#{serverUrl}/api/products/:_id"
+      @Product.action 'update',
+        method: 'PUT'
+        params:
+          _id: '@_id'
+        urlParamsSchema:
+          type: 'object'
+          required: ['_id']
+          properties:
+            _id:
+              type: 'string'
+              format: 'objectid'
+
+      expect(@Product.update({_id: '123abc'})).to.be.rejectedWith 'Url params validation failed for action \'update\': Format validation failed (objectid expected) at /_id'
+
+    it 'validates for POST/PUT/DELETE instance method', ->
+      @Product = resourceClient url: "#{serverUrl}/api/products/:_id"
+      @Product.action 'update',
+        method: 'PUT'
+        params:
+          _id: '@_id'
+        urlParamsSchema:
+          type: 'object'
+          required: ['_id']
+          properties:
+            _id:
+              type: 'string'
+              format: 'objectid'
+
+      product = new @Product({_id: '123abc'})
+      expect(product.update()).to.be.rejectedWith 'Url params validation failed for action \'update\': Format validation failed (objectid expected) at /_id'
+
+  describe 'validating queryParamsSchema', ->
+    it 'validates for GET', ->
+      @Product = resourceClient url: "#{serverUrl}/api/products/:_id"
+      @Product.action 'query',
+        method: 'GET'
+        isArray: true
+        queryParamsSchema:
+          type: 'object'
+          required: ['foodhubSlug']
+          properties:
+            foodhubSlug:
+              type: 'string'
+            isActive:
+              type: 'boolean'
+
+      expect(@Product.query({isActive: true})).to.be.rejectedWith 'Query validation failed for action \'query\': Missing required property: foodhubSlug'
+
+    it 'validates for POST/PUT/DELETE class method', ->
+      @Product = resourceClient url: "#{serverUrl}/api/products/:_id"
+      @Product.action 'update',
+        method: 'PUT'
+        queryParamsSchema:
+          type: 'object'
+          required: ['$select']
+          properties:
+            $select:
+              type: 'string'
+
+      expect(@Product.update({select: 'name'}, {name: 'apple'})).to.be.rejectedWith 'Query validation failed for action \'update\': Missing required property: $select'
+
+    it 'validates for POST/PUT/DELETE instance method', ->
+      @Product = resourceClient url: "#{serverUrl}/api/products/:_id"
+      @Product.action 'update',
+        method: 'PUT'
+        queryParamsSchema:
+          type: 'object'
+          required: ['$select']
+          properties:
+            $select:
+              type: 'string'
+
+      product = new @Product({name: 'apple'})
+      expect(product.update({select: 'name'})).to.be.rejectedWith 'Query validation failed for action \'update\': Missing required property: $select'
+
+  describe 'validating requestBodySchema', ->
+    it 'validates for PUT/POST/DELETE class methods', ->
+      @Product = resourceClient url: "#{serverUrl}/api/products/:_id"
+      @Product.action 'save',
+        method: 'POST'
+        requestBodySchema:
+          type: 'object'
+          required: ['name']
+          properties:
+            name:
+              type: 'string'
+            type:
+              type: 'string'
+              enum: ['just-in-time', 'wholesale', 'consignment']
+
+      expect(@Product.save({}, {type: 'just-in-time'})).to.be.rejectedWith 'Request body validation failed for action \'save\': Missing required property: name'
+
+    it 'validates for PUT/POST/DELETE instance methods', ->
+      @Product = resourceClient url: "#{serverUrl}/api/products/:_id"
+      @Product.action 'save',
+        method: 'POST'
+        requestBodySchema:
+          type: 'object'
+          required: ['name']
+          properties:
+            name:
+              type: 'string'
+            type:
+              type: 'string'
+              enum: ['just-in-time', 'wholesale', 'consignment']
+
+      product = new @Product({type: 'just-in-time'})
+      expect(product.save()).to.be.rejectedWith 'Request body validation failed for action \'save\': Missing required property: name'
+
+  describe 'validating responseBodySchema', ->
+    it 'validates for GET class methods', ->
+      @Product = resourceClient url: "#{serverUrl}/api/products/:_id"
+      @Product.action 'query',
+        method: 'GET'
+        isArray: true
+        responseBodySchema:
+          type: 'array'
+          items:
+            type: 'object'
+            required: ['name']
+            properties:
+              name:
+                type: 'string'
+              type:
+                type: 'string'
+                enum: ['just-in-time', 'wholesale']
+
+      api = nock(serverUrl)
+        .get('/api/products')
+        .reply(201, {name: 'apples', type: 'consignment'}) # invalid enum
+
+      expect(@Product.query()).to.be.rejectedWith 'Response body validation failed for action \'query\': Invalid type: object (expected array)'
+
+    it 'validates for PUT/POST/DELETE class methods', ->
+      @Product = resourceClient url: "#{serverUrl}/api/products/:_id"
+      @Product.action 'save',
+        method: 'POST'
+        responseBodySchema:
+          type: 'object'
+          required: ['name']
+          properties:
+            name:
+              type: 'string'
+            type:
+              type: 'string'
+              enum: ['just-in-time', 'wholesale']
+
+      api = nock(serverUrl)
+        .post('/api/products', {name: 'apples', type: 'just-in-time'})
+        .reply(201, {name: 'apples', type: 'consignment'}) # invalid enum
+
+      expect(@Product.save({}, {name: 'apples', type: 'just-in-time'})).to.be.rejectedWith 'Response body validation failed for action \'save\': No enum match for: "consignment" at /type'
+
+    it 'validates for PUT/POST/DELETE instance methods', ->
+      @Product = resourceClient url: "#{serverUrl}/api/products/:_id"
+      @Product.action 'save',
+        method: 'POST'
+        responseBodySchema:
+          type: 'object'
+          required: ['name']
+          properties:
+            name:
+              type: 'string'
+            type:
+              type: 'string'
+              enum: ['just-in-time', 'wholesale']
+
+      api = nock(serverUrl)
+        .post('/api/products', {name: 'apples', type: 'just-in-time'})
+        .reply(201, {name: 'apples', type: 'consignment'}) # invalid enum
+
+      product = new @Product({name: 'apples', type: 'just-in-time'})
+      expect(product.save()).to.be.rejectedWith 'Response body validation failed for action \'save\': No enum match for: "consignment" at /type'
+
+  describe 'banUnknownProperties', ->
+    it 'does banUnknownProperties for all actions if true on resource config', ->
+      @Product = resourceClient
+        url: "#{serverUrl}/api/products/:_id"
+        banUnknownProperties: true
+
+      @Product.action 'query',
+        method: 'GET'
+        isArray: true
+        queryParamsSchema:
+          type: 'object'
+          required: ['foodhubSlug']
+          properties:
+            foodhubSlug:
+              type: 'string'
+            isActive:
+              type: 'boolean'
+
+      expect(@Product.query({foodhubSlug: 'sfbay', isActive: true, search: 'apple'})).to.be.rejectedWith 'Query validation failed for action \'query\': Unknown property (not in schema) at /search'
+
+    it 'does not banUnknownProperties if not configured', ->
+      @Product = resourceClient
+        url: "#{serverUrl}/api/products/:_id"
+
+      @Product.action 'query',
+        method: 'GET'
+        isArray: true
+        queryParamsSchema:
+          type: 'object'
+          required: ['foodhubSlug']
+          properties:
+            foodhubSlug:
+              type: 'string'
+            isActive:
+              type: 'boolean'
+
+      api = nock(serverUrl)
+        .get('/api/products?foodhubSlug=sfbay&isActive=true&search=apple')
+        .reply(201, {name: 'apples', type: 'consignment'})
+      expect(@Product.query({foodhubSlug: 'sfbay', isActive: true, search: 'apple'})).to.be.fulfilled
+


### PR DESCRIPTION
Now supports optional JSON schema validation for url params, query params, request body, and response body. To use, pass the JSON schema into the configuration like so:

``` javascript
var Product = resourceClient({
  url: 'http://www.mysite.com/api/products/:_id',
  // recommended that you ban unkown properties when testing.
  banUnknownProperties: settings.env === 'test'
});

Product.action('update', {
  method: 'PUT'
  urlParamsSchema: require('./product/schemas/update/url_params.json')
  queryParamsSchema: require('./product/schemas/update/query_params.json')
  requestBodySchema: require('./product/schemas/update/request_body.json')
  responseBodySchema: require('./product/schemas/update/response_body.json')
})
```

It will reject / error if request validation fails.
