### PR TITLE
Retry for Network Errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bluebird": "^2.9.30",
     "goodeggs-json-schema-validator": "^2.0.2",
     "lodash": "^3.0.0",
-    "request": "2.54.0",
+    "requestretry": "^1.4.0",
     "url-assembler": "0.0.3"
   },
   "devDependencies": {
@@ -34,7 +34,8 @@
     "coffee-script": ">=1.7.x",
     "fibrous": "^0.3.3",
     "mocha": "~1.x.x",
-    "nock": "^1.6.1"
+    "nock": "^1.6.1",
+    "request": "^2.61.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,5 +1,5 @@
 Promise = require 'bluebird'
-request = Promise.promisify require 'request'
+request = Promise.promisify require 'requestretry'
 _ = require 'lodash'
 requestValidator = require './request_validator'
 urlBuilder = require './url_builder'
@@ -13,6 +13,9 @@ Create resource with default configuration
 module.exports = resourceClient = (resourceConfig) ->
   resourceConfig.params ?= {}
   resourceConfig.json ?= true
+  resourceConfig.maxAttempts ?= 5
+  resourceConfig.retryDelay ?= 5000
+  resourceConfig.retryStrategy ?= request.RetryStrategies.NetworkError
 
   class Resource
     constructor: (newObject) ->

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -8,14 +8,14 @@ defaultActions = require './default_actions'
 
 ###
 Create resource with default configuration
-@param {Object} [resourceConfig] - configuration shared for all actions on this resource
+@param {Object} [resourceOptions] - configuration shared for all actions on this resource
 ###
-module.exports = resourceClient = (resourceConfig) ->
-  resourceConfig.params ?= {}
-  resourceConfig.json ?= true
-  resourceConfig.maxAttempts ?= 5
-  resourceConfig.retryDelay ?= 5000
-  resourceConfig.retryStrategy ?= request.RetryStrategies.NetworkError
+module.exports = resourceClient = (resourceOptions) ->
+  resourceOptions.params ?= {}
+  resourceOptions.json ?= true
+  resourceOptions.maxAttempts ?= 5
+  resourceOptions.retryDelay ?= 5000
+  resourceOptions.retryStrategy ?= request.RetryStrategies.NetworkError
 
   class Resource
     constructor: (newObject) ->
@@ -28,16 +28,16 @@ module.exports = resourceClient = (resourceConfig) ->
   ###
   Register an action for the resource
   @param {String} actionName - name of action being registered
-  @param {Object} [actionConfig] - configuration for this particular action
+  @param {Object} [actionOptions] - configuration for this particular action
   ###
-  Resource.action = (actionName, actionConfig) ->
+  Resource.action = (actionName, actionOptions) ->
     throw new TypeError 'actionName must be a string' unless typeof actionName is 'string'
-    throw new TypeError 'actionConfig.method must be GET POST PUT or DELETE' unless actionConfig.method in ['GET', 'POST', 'PUT', 'DELETE']
+    throw new TypeError 'actionOptions.method must be GET POST PUT or DELETE' unless actionOptions.method in ['GET', 'POST', 'PUT', 'DELETE']
 
-    actionConfig.params ?= {}
-    actionUrl = actionConfig.url or resourceConfig.url
+    actionOptions.params ?= {}
+    actionUrl = actionOptions.url or resourceOptions.url
 
-    if actionConfig.method is 'GET'
+    if actionOptions.method is 'GET'
       ###
       Send a GET request with specified configuration
       @param {Object} [params] - url params and query params for this action
@@ -50,18 +50,18 @@ module.exports = resourceClient = (resourceConfig) ->
         requestParams = opts.shift() or {}
         requestOptions = opts.pop() or {}
         requestOptions.url = do ->
-          mergedParams = _.assign({}, resourceConfig.params, actionConfig.params, requestParams)
+          mergedParams = _.assign({}, resourceOptions.params, actionOptions.params, requestParams)
           urlBuilder.build(actionUrl, mergedParams)
         Promise.try =>
-          requestValidator.validateUrlParams({requestParams, actionConfig, resourceConfig, actionName})
-          requestValidator.validateQueryParams({requestParams, actionConfig, resourceConfig, actionName})
-          mergedOptions = _.merge({}, resourceConfig, actionConfig, requestOptions)
+          requestValidator.validateUrlParams({requestParams, actionOptions, resourceOptions, actionName})
+          requestValidator.validateQueryParams({requestParams, actionOptions, resourceOptions, actionName})
+          mergedOptions = _.merge({}, resourceOptions, actionOptions, requestOptions)
           request(mergedOptions)
         .spread (response) ->
-          handleResponse({response, actionConfig, actionName})
+          handleResponse({response, actionOptions, actionName})
         .nodeify(done)
 
-    else # actionConfig.method is PUT, POST, or DELETE
+    else # actionOptions.method is PUT, POST, or DELETE
       ###
       Send a PUT, POST, or DELETE request with specified configuration
       @param {Object} [params] - url params and query params for this action
@@ -77,16 +77,16 @@ module.exports = resourceClient = (resourceConfig) ->
         requestOptions = opts.pop() or {}
         requestOptions.body = requestBody
         requestOptions.url = do ->
-          mergedParams = _.assign({}, resourceConfig.params, actionConfig.params, requestParams)
+          mergedParams = _.assign({}, resourceOptions.params, actionOptions.params, requestParams)
           urlBuilder.build(actionUrl, mergedParams, requestOptions.body)
         Promise.try =>
-          requestValidator.validateUrlParams({requestParams, actionConfig, resourceConfig, actionName, requestBody})
-          requestValidator.validateQueryParams({requestParams, actionConfig, resourceConfig, actionName, requestBody})
-          requestValidator.validateRequestBody({actionConfig, resourceConfig, actionName, requestBody})
-          mergedOptions = _.merge({}, resourceConfig, actionConfig, requestOptions)
+          requestValidator.validateUrlParams({requestParams, actionOptions, resourceOptions, actionName, requestBody})
+          requestValidator.validateQueryParams({requestParams, actionOptions, resourceOptions, actionName, requestBody})
+          requestValidator.validateRequestBody({actionOptions, resourceOptions, actionName, requestBody})
+          mergedOptions = _.merge({}, resourceOptions, actionOptions, requestOptions)
           request(mergedOptions)
         .spread (response) =>
-          handleResponse({response, actionConfig, actionName})
+          handleResponse({response, actionOptions, actionName})
         .nodeify(done)
 
       ###
@@ -103,40 +103,40 @@ module.exports = resourceClient = (resourceConfig) ->
         requestOptions = opts.pop() or {}
         requestOptions.body = @
         requestOptions.url = do ->
-          mergedParams = _.assign({}, resourceConfig.params, actionConfig.params, requestParams)
+          mergedParams = _.assign({}, resourceOptions.params, actionOptions.params, requestParams)
           urlBuilder.build(actionUrl, mergedParams, requestOptions.body)
         Promise.try =>
-          requestValidator.validateUrlParams({requestParams, actionConfig, resourceConfig, actionName, requestBody: @})
-          requestValidator.validateQueryParams({requestParams, actionConfig, resourceConfig, actionName, requestBody: @})
-          requestValidator.validateRequestBody({actionConfig, resourceConfig, actionName, requestBody: @})
-          mergedOptions = _.merge({}, resourceConfig, actionConfig, requestOptions)
+          requestValidator.validateUrlParams({requestParams, actionOptions, resourceOptions, actionName, requestBody: @})
+          requestValidator.validateQueryParams({requestParams, actionOptions, resourceOptions, actionName, requestBody: @})
+          requestValidator.validateRequestBody({actionOptions, resourceOptions, actionName, requestBody: @})
+          mergedOptions = _.merge({}, resourceOptions, actionOptions, requestOptions)
           request(mergedOptions)
         .spread (response) =>
-          handleResponse({response, actionConfig, resourceConfig, actionName, originalObject: @})
+          handleResponse({response, actionOptions, resourceOptions, actionName, originalObject: @})
         .nodeify(done)
 
 
   ###
   @param {Object} response - request response object
-  @param {Object} actionConfig
+  @param {Object} actionOptions
   @param {String} actionName
   @param {Object} [originalObject] - original resource instance that was saved
     - once successful, original instance will be updated in place with the response object
   ###
-  handleResponse = ({response, actionConfig, actionName, originalObject}) ->
+  handleResponse = ({response, actionOptions, actionName, originalObject}) ->
     throw new TypeError 'response must be an object' unless typeof response is 'object'
-    throw new TypeError 'actionConfig must be an object' unless typeof actionConfig is 'object'
+    throw new TypeError 'actionOptions must be an object' unless typeof actionOptions is 'object'
     throw new TypeError 'actionName must be a string' unless typeof actionName is 'string'
     throw new TypeError 'originalObject must be an object' if originalObject? and typeof originalObject isnt 'object'
 
-    actionConfig ?= {}
+    actionOptions ?= {}
 
     if 200 <= response.statusCode < 300
-      requestValidator.validateResponseBody({actionConfig, resourceConfig, actionName, responseBody: response.body})
+      requestValidator.validateResponseBody({actionOptions, resourceOptions, actionName, responseBody: response.body})
 
       if Array.isArray(response.body)
         resources = response.body.map (resource) -> new Resource(resource)
-        resources = resources[0] if actionConfig.returnFirst
+        resources = resources[0] if actionOptions.returnFirst
         return resources
       else
         resource =
@@ -156,7 +156,7 @@ module.exports = resourceClient = (resourceConfig) ->
   ###
   Add default methods.
   ###
-  for actionName, actionConfig of defaultActions
-    Resource.action actionName, actionConfig
+  for actionName, actionOptions of defaultActions
+    Resource.action actionName, actionOptions
 
   return Resource

--- a/src/request_validator.coffee
+++ b/src/request_validator.coffee
@@ -8,83 +8,83 @@ module.exports =
   ###
   Throws if url params invalid
   @param {Object} requestParams
-  @param {Object} actionConfig
-  @param {Object} resourceConfig
+  @param {Object} actionOptions
+  @param {Object} resourceOptions
   @param {String} actionName
   @param {Object} [requestBody] - if the request has a body, use for populating '@' url params
   ###
-  validateUrlParams: ({requestParams, actionConfig, resourceConfig, actionName, requestBody}) ->
+  validateUrlParams: ({requestParams, actionOptions, resourceOptions, actionName, requestBody}) ->
     throw new TypeError 'requestParams must be an object' unless typeof requestParams is 'object'
-    throw new TypeError 'actionConfig must be an object' unless typeof actionConfig is 'object'
-    throw new TypeError 'resourceConfig must be an object' unless typeof resourceConfig is 'object'
+    throw new TypeError 'actionOptions must be an object' unless typeof actionOptions is 'object'
+    throw new TypeError 'resourceOptions must be an object' unless typeof resourceOptions is 'object'
     throw new TypeError 'actionName must be a string' unless typeof actionName is 'string'
     throw new TypeError 'requestBody must be a string' if requestBody? and typeof requestBody isnt 'object'
 
-    return unless actionConfig.urlParamsSchema?
-    urlParams = getUrlParamValues({requestParams, actionConfig, resourceConfig, requestBody})
+    return unless actionOptions.urlParamsSchema?
+    urlParams = getUrlParamValues({requestParams, actionOptions, resourceOptions, requestBody})
 
-    validate clean(urlParams), actionConfig.urlParamsSchema,
+    validate clean(urlParams), actionOptions.urlParamsSchema,
       errorPrefix: "Url params validation failed for action '#{actionName}'"
-      banUnknownProperties: getBanUnkownProperties({actionConfig, resourceConfig})
+      banUnknownProperties: getBanUnkownProperties({actionOptions, resourceOptions})
 
 
   ###
   Throws if query params invalid
   @param {Object} requestParams
-  @param {Object} actionConfig
-  @param {Object} resourceConfig
+  @param {Object} actionOptions
+  @param {Object} resourceOptions
   @param {String} actionName
   @param {Object} [requestBody] - if the request has a body, use for populating '@' query params
   ###
-  validateQueryParams: ({requestParams, actionConfig, resourceConfig, actionName, requestBody}) ->
+  validateQueryParams: ({requestParams, actionOptions, resourceOptions, actionName, requestBody}) ->
     throw new TypeError 'requestParams must be an object' unless typeof requestParams is 'object'
-    throw new TypeError 'actionConfig must be an object' unless typeof actionConfig is 'object'
-    throw new TypeError 'resourceConfig must be an object' unless typeof resourceConfig is 'object'
+    throw new TypeError 'actionOptions must be an object' unless typeof actionOptions is 'object'
+    throw new TypeError 'resourceOptions must be an object' unless typeof resourceOptions is 'object'
     throw new TypeError 'actionName must be a string' unless typeof actionName is 'string'
     throw new TypeError 'requestBody must be a string' if requestBody? and typeof requestBody isnt 'object'
 
-    return unless actionConfig.queryParamsSchema?
-    queryParams = getQueryParamValues({requestParams, actionConfig, resourceConfig, requestBody})
+    return unless actionOptions.queryParamsSchema?
+    queryParams = getQueryParamValues({requestParams, actionOptions, resourceOptions, requestBody})
 
-    validate clean(queryParams), actionConfig.queryParamsSchema,
+    validate clean(queryParams), actionOptions.queryParamsSchema,
       errorPrefix: "Query validation failed for action '#{actionName}'"
-      banUnknownProperties: getBanUnkownProperties({actionConfig, resourceConfig})
+      banUnknownProperties: getBanUnkownProperties({actionOptions, resourceOptions})
 
 
   ###
   Throws if request body invalid
-  @param {Object} actionConfig
-  @param {Object} resourceConfig
+  @param {Object} actionOptions
+  @param {Object} resourceOptions
   @param {Object} actionName
   @param {Object} requestBody
   ###
-  validateRequestBody: ({actionConfig, resourceConfig, actionName, requestBody}) ->
-    throw new TypeError 'actionConfig must be an object' unless typeof actionConfig is 'object'
-    throw new TypeError 'resourceConfig must be an object' unless typeof resourceConfig is 'object'
+  validateRequestBody: ({actionOptions, resourceOptions, actionName, requestBody}) ->
+    throw new TypeError 'actionOptions must be an object' unless typeof actionOptions is 'object'
+    throw new TypeError 'resourceOptions must be an object' unless typeof resourceOptions is 'object'
     throw new TypeError 'actionName must be a string' unless typeof actionName is 'string'
     throw new TypeError 'requestBody must be an object' unless typeof requestBody is 'object'
 
-    validate clean(requestBody), actionConfig.requestBodySchema,
+    validate clean(requestBody), actionOptions.requestBodySchema,
       errorPrefix: "Request body validation failed for action '#{actionName}'"
-      banUnknownProperties: getBanUnkownProperties({actionConfig, resourceConfig})
+      banUnknownProperties: getBanUnkownProperties({actionOptions, resourceOptions})
 
 
   ###
   Throws if response body invalid
-  @param {Object} actionConfig
-  @param {Object} resourceConfig
+  @param {Object} actionOptions
+  @param {Object} resourceOptions
   @param {Object} actionName
   @param {Object} responseBody
   ###
-  validateResponseBody: ({actionConfig, resourceConfig, actionName, responseBody}) ->
-    throw new TypeError 'actionConfig must be an object' unless typeof actionConfig is 'object'
-    throw new TypeError 'resourceConfig must be an object' unless typeof resourceConfig is 'object'
+  validateResponseBody: ({actionOptions, resourceOptions, actionName, responseBody}) ->
+    throw new TypeError 'actionOptions must be an object' unless typeof actionOptions is 'object'
+    throw new TypeError 'resourceOptions must be an object' unless typeof resourceOptions is 'object'
     throw new TypeError 'actionName must be a string' unless typeof actionName is 'string'
     throw new TypeError 'responseBody must be an object' unless typeof responseBody is 'object'
 
-    validate clean(responseBody), actionConfig.responseBodySchema,
+    validate clean(responseBody), actionOptions.responseBodySchema,
       errorPrefix: "Response body validation failed for action '#{actionName}'"
-      banUnknownProperties: getBanUnkownProperties({actionConfig, resourceConfig})
+      banUnknownProperties: getBanUnkownProperties({actionOptions, resourceOptions})
 
 
 # remove all prototype properties, and undefined fields
@@ -102,9 +102,9 @@ getUrlParams = (url) ->
   matches
 
 
-getUrlParamValues = ({requestParams, actionConfig, resourceConfig, requestBody}) ->
-  allParams = _.assign({}, resourceConfig.params, actionConfig.params, requestParams)
-  url = if actionConfig.url? then actionConfig.url else resourceConfig.url
+getUrlParamValues = ({requestParams, actionOptions, resourceOptions, requestBody}) ->
+  allParams = _.assign({}, resourceOptions.params, actionOptions.params, requestParams)
+  url = if actionOptions.url? then actionOptions.url else resourceOptions.url
   urlParams = getUrlParams(url)
   paramsToOmit = []
 
@@ -122,18 +122,18 @@ getUrlParamValues = ({requestParams, actionConfig, resourceConfig, requestBody})
   _.omit(allParams, paramsToOmit)
 
 
-getBanUnkownProperties = ({actionConfig, resourceConfig}) ->
-  if actionConfig.banUnknownProperties?
-    actionConfig.banUnknownProperties
-  else if resourceConfig.banUnknownProperties?
-    resourceConfig.banUnknownProperties
+getBanUnkownProperties = ({actionOptions, resourceOptions}) ->
+  if actionOptions.banUnknownProperties?
+    actionOptions.banUnknownProperties
+  else if resourceOptions.banUnknownProperties?
+    resourceOptions.banUnknownProperties
   else
     false
 
 
-getQueryParamValues = ({requestParams, actionConfig, resourceConfig, requestBody}) ->
-  url = if actionConfig.url? then actionConfig.url else resourceConfig.url
-  allParams = _.assign({}, resourceConfig.params, actionConfig.params, requestParams)
+getQueryParamValues = ({requestParams, actionOptions, resourceOptions, requestBody}) ->
+  url = if actionOptions.url? then actionOptions.url else resourceOptions.url
+  allParams = _.assign({}, resourceOptions.params, actionOptions.params, requestParams)
   paramsToOmit = []
 
   # handle params with @ in value (e.g. {id: '@_id'})


### PR DESCRIPTION
If a request gets a network error such as `ECONNRESET`, `ENOTFOUND`, `ECONNREFUSED` or `EPIPE`, automatically retry since these errors are usually recoverable.

Note, this uses the [requestretry](https://github.com/FGRibreau/node-request-retry) module. By default, it will retry up to 5 times, and wait 5 seconds before each retry. You can override these values in the resource configuration like so:

``` coffee
Product = resourceClient
  url: 'http://www.mysite.com/api/products/:_id'
  headers:
    'X-Secret-Token': 'ABCD1234'
  maxAttempts: 3
  retryDelay: 10000
  retryStrategy: (err, response) ->
    # retry if we get a 500 status code as a response...
    500 <= response.statusCode < 600
```
